### PR TITLE
socat-forwarder image

### DIFF
--- a/socat-forwarder/Dockerfile
+++ b/socat-forwarder/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:latest
+MAINTAINER Nikolay Sokolov <nsokolov@qubell.com>
+
+RUN apt-get update && apt-get install -y socat
+ADD run.sh /run.sh
+
+RUN apt-get clean
+RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENTRYPOINT ["/run.sh"]
+CMD []

--- a/socat-forwarder/run.sh
+++ b/socat-forwarder/run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+
+ARGS=""
+NTUNNELS=0
+
+while getopts ":L:d" opt; do
+  case $opt in
+    L)
+      case "$OPTARG" in
+        *:*:*)
+          read -sr EXPOSED_PORT ORIGINAL_HOST ORIGINAL_PORT <<< $(echo "$OPTARG" | tr ":" " ")
+          ARGS="$ARGS TCP4-LISTEN:$EXPOSED_PORT,fork,reuseaddr TCP4:$ORIGINAL_HOST:$ORIGINAL_PORT"
+          NTUNNELS=$[ $NTUNNELS + 1 ] 
+          ;;
+        *)
+          echo "unknown arg format. -L PORT:HOST:PORT is supported"
+          exit 1
+      esac
+      ;;
+    d)
+      DRY_RUN=1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ ! x$DRY_RUN == x1 ]; then
+  echo $ARGS | xargs -P $NTUNNELS -n 2 bash -c 'socat $0 $1'
+else
+  echo "Dry run, generated config:"
+  echo "=========================="
+  echo
+  echo $ARGS | xargs -n 2 bash -c 'echo socat $0 $1'
+fi


### PR DESCRIPTION
Image that provides simple TCP forwarding facilities. Command-line option format is the same as for SSL -L flag:

```
docker run -d -P --expose 80 chemikadze/socat-forwarder -L 80:ya.ru:80
```
