### PR TITLE
Added missing EXPOSE on artifact-builder

### DIFF
--- a/artifact-builder/Dockerfile
+++ b/artifact-builder/Dockerfile
@@ -18,4 +18,6 @@ ENV PUBLISH_PATH application.war
 
 ADD run.sh /run.sh
 
+EXPOSE 80
+
 CMD /run.sh


### PR DESCRIPTION
Affects operation of latest component-war-docker on non-ECS docker service.
