### PR TITLE
Base image for python scripting service

### DIFF
--- a/python-scripting/Dockerfile
+++ b/python-scripting/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:latest
+
+RUN pip install pyyaml
+
+ADD scripts/ /

--- a/python-scripting/scripts/echo.py
+++ b/python-scripting/scripts/echo.py
@@ -1,0 +1,6 @@
+#!/usr/local/bin/python
+
+import sys, yaml
+
+data = yaml.safe_load(sys.stdin)
+yaml.dump(data, sys.stdout)

--- a/python-scripting/scripts/invoke.py
+++ b/python-scripting/scripts/invoke.py
@@ -1,0 +1,15 @@
+#!/usr/local/bin/python
+
+import sys, yaml, subprocess
+
+stdin = yaml.safe_load(sys.stdin)
+script = stdin['script']
+arguments = stdin['arguments']
+
+process = subprocess.Popen([script], stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
+yaml.dump(arguments, process.stdin)
+process.stdin.close()
+
+output = yaml.safe_load(process.stdout)
+stdout = { "results": output }
+yaml.dump(stdout, sys.stdout)


### PR DESCRIPTION
`invoke.py` accepts the following YAML on stdin:

``` yaml
script: /echo.py # <script name>
arguments: {} # <arguments>
```

The `<script name>` is launched and `<arguments>` are passed to stdin as yaml. Then `<script name>` stdout is parsed as YAML and returned to the caller under `results` tag:

``` yaml
results: {} # <script stdout yaml>
```
