### PR TITLE
Remove name field from fake vm launch response

### DIFF
--- a/fake-vm-component-scripts/fake-vm/launch.py
+++ b/fake-vm-component-scripts/fake-vm/launch.py
@@ -33,7 +33,6 @@ for (vm, instance_id) in instances:
 result = {
     'instances': {
         vm.vmid: {
-            'name': vm.name,
             'instanceId': instance_id,  # pass instance for correlation
             'status': {
                 'flags': {'active': True, 'converging': False, 'failed': False}


### PR DESCRIPTION
This returns `name: null` and is not needed.
@netvl 
