### PR TITLE
Added support for colors on fake VMs (component references example)

### DIFF
--- a/fake-vm-component-scripts/fake-vm/discover.py
+++ b/fake-vm-component-scripts/fake-vm/discover.py
@@ -4,7 +4,14 @@ import sys
 import yaml
 import fvm
 
+arguments = yaml.safe_load(sys.stdin)
+
+color = (arguments or {}).get('configuration', {}).get('configuration.color')
+
 vms = fvm.load_fake_vms()
+
+if color:
+    vms = [vm for vm in vms if vm.color == color]
 
 def get_model(vm):
     if vm.name:
@@ -13,7 +20,8 @@ def get_model(vm):
             'interfaces': {
                 'info': {
                     'signals': {
-                        'vmid': vm.vmid
+                        'vmid': vm.vmid,
+                        'color': vm.color,
                     }
                 }
             }

--- a/fake-vm-component-scripts/fake-vm/fvm.py
+++ b/fake-vm-component-scripts/fake-vm/fvm.py
@@ -23,8 +23,20 @@ class FakeVm:
     def name(self):
         del self.model['name']
 
+    @property
+    def color(self):
+        return self.model.get('color')
+
+    @color.setter
+    def color(self, value):
+        self.model['color'] = value
+
+    @color.deleter
+    def color(self):
+        del self.model['color']
+
     def __str__(self):
-        return "FakeVm({}, {})".format(self.vmid, self.name)
+        return "FakeVm({}, {}, {})".format(self.vmid, self.color, self.name)
 
     def __repr__(self):
         return str(self)

--- a/fake-vm-component-scripts/fake-vm/healthCheck.py
+++ b/fake-vm-component-scripts/fake-vm/healthCheck.py
@@ -25,7 +25,8 @@ for vmid in ids:
         interfaces = {
             'info': {
                 'signals': {
-                    'vmid': vmid
+                    'vmid': vmid,
+                    'color': vm.color,
                 }
             }
         }
@@ -35,10 +36,26 @@ for vmid in ids:
 
         if 'login' in vm.model:
             interfaces['info']['signals']['login'] = vm.model['login']
-        
+
+        components = {}
+        if 'links' in vm.model:
+            for color, linked_fvms in vm.model['links'].items():
+                # color will map to group name in the tree
+                components[color] = {'children': {}}
+                for linked_id in linked_fvms:
+                    components[color]['children'] = {
+                        linked_id: {  # linked_id will map to component name in the tree
+                            'reference': {
+                                'type': "{}-vms".format(color),
+                                'id': linked_id
+                            }
+                        }
+                    }
+
         vm_infos[vmid] = {
             'status': status,
-            'interfaces': interfaces
+            'interfaces': interfaces,
+            'components': components,
         }
     else:
         # a vm is absent, set its status to destroyed

--- a/fake-vm-component-scripts/fake-vm/launch.py
+++ b/fake-vm-component-scripts/fake-vm/launch.py
@@ -25,6 +25,11 @@ for (instance_id, params) in arguments.get('launch-instances', {}).items():
     # merge instance configuration
     model.update(fix_config_keys(params.get('configuration', {}).items()))
 
+    # we now need color on each VM
+    if not 'color' in model:
+        print("Instance {} has no color".format(instance_id), file=sys.stderr)
+        sys.exit(1)
+
     instances.append((fvm.FakeVm(vmid, model), instance_id))
 
 for (vm, instance_id) in instances:


### PR DESCRIPTION
This PR adds support for colors on fake VMs, which can be used to check how references on scriptable components work.

First, this PR adds a mandatory property on each VM called "color". `manage.py` script is updated accordingly with `--color` option in its `create` and `modify` actions. `launch.py` script accepts the color either from factory configuration or from component configuration, and it will exit with an error if no color is available. `healthCheck.py` now publishes fake VM's color in its signals. `discovery.py` now accepts a configuration option from the factory which limits the scope of discovered fake VMs to a specific color. This way it is possible to create multiple factories, each having a different associated color, and discovery performed by these factories will only result in fake VMs of the respective color.

Second, this PR introduces links between fake VMs. Each VM may be linked to an arbitrary number of other VMs. These links may only be tweaked with `manage.py` script by passing `--link <color>:<vmid>` andl/or `--unlink <color>:<vmid>` options (arbitrary number of them) to the `modify` action of `manage.py` or `--link <color>:<vmid>` option to the `create` action. Afterwards `healthCheck.py` script will advertise all linked VMs through the `components:` mapping:

``` yaml
instances:
  vm-123456:
    status: ...
    interfaces:
      info:
        signals:
          vmid: vm-123456
          color: yellow
    components:
      green:
        children:
          vm-98765:
            reference:
              type: green-vms
              id: vm-98765
          vm-00000:
            reference:
              type: green-vms
              id: vm-00000
      blue:
        children:
          vm-829402:
            reference:
              type: blue-vms
              id: vm-829402
```

Note that linked fake VMs are grouped by their color, and their type (which is directly tied to resolution interfaces in the respective factory) has form `<color>-vms`.

It may not be clear why it is needed to specify the color in `--link`/`--unlink` option; after all, it looks like that it should be possible to load it directly from the linked fake VM. This is done intentionally: it is possible to create a link to a fake VM which does not exist yet. This is needed to test how the platform reacts to components which can't be resolved at the moment they are returned by the discovery process.
